### PR TITLE
Change arch iso URL to ensure it doesn't break on future updates

### DIFF
--- a/iso.json
+++ b/iso.json
@@ -145,11 +145,11 @@
     },
     {
         "name": "ArchLinux",
-        "iso_url": "http://archlinux.mirror.garr.it/archlinux/iso/latest/archlinux-2025.02.01-x86_64.iso",
+        "iso_url": "http://archlinux.mirror.garr.it/archlinux/iso/latest/archlinux-x86_64.iso",
         "help": "https://archlinux.org",
         "os_family": "linux",
         "os_flavour": "arch",
-        "os_version": "2025.02.01"
+        "os_version": "latest"
     },
     {
         "name": "TempleOS",


### PR DESCRIPTION
With arch being a rolling-release distro, providing outdated images isn't really in the interest of the end user.

Furthermore, the link to the latest explicit version (e.g. [`archlinux-2025.02.01-x86_64.iso`](http://archlinux.mirror.garr.it/archlinux/iso/latest/archlinux-2025.03.01-x86_64.iso)) is only valid for one month before the file gets moved (and eventually removed). To avoid having to manually update the iso URL, it's better to provide a link to the latest version ([`archlinux-x86_64.iso`](http://archlinux.mirror.garr.it/archlinux/iso/latest/archlinux-x86_64.iso)) and set the version in the json as `latest` or `rolling`.